### PR TITLE
include wp post metas in JSON export

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "mime-types": "^2.1.27",
     "moment": "^2.25.3",
     "needle": "^2.4.1",
+    "phpunserialize": "^1.3.0",
     "turndown": "^6.0.0"
   }
 }


### PR DESCRIPTION
Very nice starter project, thanks !
(But You should update it, it's way outdated and i'm sure a lot of people would be interested)
Here's a little contribution to include post metas in the JSON file generated.